### PR TITLE
feat: Metal per-op CPU fallback + virtual destructor fix

### DIFF
--- a/src/cosyvoice-graph.cpp
+++ b/src/cosyvoice-graph.cpp
@@ -150,7 +150,7 @@ ggml_tensor* Conv1d::build_cgraph(ggml_context* ctx, ggml_tensor* x, int s, int 
 			xs[i] = unsqueeze(ctx,
 				ggml_im2col(ctx,
 					ws[i],
-					xs[i],
+					ggml_cont(ctx, xs[i]),
 					s, 0, p, 0, d, 0,
 					false, weight->type),
 				2);

--- a/src/cosyvoice-internal.h
+++ b/src/cosyvoice-internal.h
@@ -14,8 +14,12 @@
 
 struct ggml_backend_op_capabilities
 {
-	bool concat_i32 : 1;
-	bool repeat_f16 : 1;
+	bool concat_i32    : 1;
+	bool repeat_f16    : 1;
+	bool pad           : 1;
+	bool pad_ext       : 1;
+	bool pad_reflect_1d: 1;
+	bool im2col        : 1;
 };
 
 struct cosyvoice_model;

--- a/src/cosyvoice-model.cpp
+++ b/src/cosyvoice-model.cpp
@@ -52,6 +52,25 @@ cosyvoice_model::cosyvoice_model(ggml_backend_t backend, const cosyvoice_context
 	a = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F16, 11, 4, 51);
 	a = ggml_repeat_4d(ctx0.get(), a, 11, 4, 51, 4);
 	op_caps.repeat_f16 = ggml_backend_supports_op(backend, a);
+
+	a = ggml_new_tensor_2d(ctx0.get(), GGML_TYPE_F32, 16, 4);
+	a = ggml_pad(ctx0.get(), a, 4, 0, 0, 0);
+	op_caps.pad = ggml_backend_supports_op(backend, a);
+
+	a = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 16, 4, 1);
+	a = ggml_pad_ext(ctx0.get(), a, 2, 0, 0, 0, 0, 0, 0, 0);
+	op_caps.pad_ext = ggml_backend_supports_op(backend, a);
+
+	a = ggml_new_tensor_1d(ctx0.get(), GGML_TYPE_F32, 16);
+	a = ggml_pad_reflect_1d(ctx0.get(), a, 1, 0);
+	op_caps.pad_reflect_1d = ggml_backend_supports_op(backend, a);
+
+	{
+		ggml_tensor* w = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 3, 4, 8);
+		a = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 16, 4, 1);
+		a = ggml_im2col(ctx0.get(), w, a, 1, 0, 0, 0, 1, 0, false, GGML_TYPE_F32);
+		op_caps.im2col = ggml_backend_supports_op(backend, a);
+	}
 }
 
 bool cosyvoice_model::using_builtin_sampler() const

--- a/src/cosyvoice-modules.h
+++ b/src/cosyvoice-modules.h
@@ -244,6 +244,7 @@ struct CausalMaskedDiffWithDiT : Module
 
 struct CausalConv1dBase : Conv1d
 {
+	virtual ~CausalConv1dBase() = default;
 	virtual ggml_tensor* build_cgraph(ggml_context* ctx, ggml_tensor* x) const = 0;
 };
 

--- a/src/cosyvoice-tts.cpp
+++ b/src/cosyvoice-tts.cpp
@@ -161,21 +161,10 @@ static void set_graph_backend(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_
 
     for (int i = 0; i != nodes; ++i) {
         auto node = ggml_graph_node(gf, i);
-        if (node->op == GGML_OP_CUSTOM)
-        {
-            do {
-                ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
-                if (++i == nodes) return;
-                node = ggml_graph_node(gf, i);
-            } while ((node->op == GGML_OP_VIEW || node->op == GGML_OP_PERMUTE));
-
-            goto set_main_backend;
-        }
+        if (cpu_backend && !ggml_backend_supports_op(backend, node))
+            ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
         else
-        {
-        set_main_backend:
             ggml_backend_sched_set_tensor_backend(sched, node, backend);
-        }
     }
 }
 
@@ -223,7 +212,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
 
     auto feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len);
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), nullptr);
+    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
     ggml_backend_sched_synchronize(sched.get());
     ggml_backend_sched_alloc_graph(sched.get(), gf);
 
@@ -256,7 +245,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len, &t_leaf);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), nullptr);
+    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);
@@ -285,7 +274,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, static_cast<int>(flow.decoder.t_span.size() - 1), op_caps, cut_len, nullptr);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), nullptr);
+    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);

--- a/src/cosyvoice-tts.cpp
+++ b/src/cosyvoice-tts.cpp
@@ -154,6 +154,8 @@ bool cosyvoice_model_3::llm_job(const int* text, uint32_t text_len, cosyvoice_pr
     return true;
 }
 
+// Route CUSTOM ops (and their trailing VIEW/PERMUTE) to CPU, everything else to GPU.
+// Used for HiFT where only FFT/ISTFT custom ops need CPU — all other ops and weights stay on GPU.
 static void set_graph_backend(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend, ggml_backend_t cpu_backend, int nodes = -1)
 {
     if (nodes < 0)
@@ -161,10 +163,61 @@ static void set_graph_backend(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_
 
     for (int i = 0; i != nodes; ++i) {
         auto node = ggml_graph_node(gf, i);
+        if (node->op == GGML_OP_CUSTOM)
+        {
+            do {
+                ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
+                if (++i == nodes) return;
+                node = ggml_graph_node(gf, i);
+            } while ((node->op == GGML_OP_VIEW || node->op == GGML_OP_PERMUTE));
+
+            goto set_main_backend;
+        }
+        else
+        {
+        set_main_backend:
+            ggml_backend_sched_set_tensor_backend(sched, node, backend);
+        }
+    }
+}
+
+// Route unsupported ops to CPU based on ggml_backend_supports_op.
+// Used for Flow where PAD/IM2COL may be unsupported on some backends (e.g., Metal pre-M5).
+// Virtual ops (VIEW, RESHAPE, PERMUTE, TRANSPOSE) follow their consumer's backend.
+static void set_graph_backend_per_op(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend, ggml_backend_t cpu_backend, int nodes = -1)
+{
+    if (nodes < 0)
+        nodes = ggml_graph_n_nodes(gf);
+
+    auto is_virtual = [](ggml_op op) {
+        return op == GGML_OP_VIEW || op == GGML_OP_RESHAPE || op == GGML_OP_PERMUTE || op == GGML_OP_TRANSPOSE;
+    };
+
+    // Pass 1: assign non-virtual ops based on supports_op
+    for (int i = 0; i != nodes; ++i) {
+        auto node = ggml_graph_node(gf, i);
+        if (is_virtual(node->op))
+            continue;
         if (cpu_backend && !ggml_backend_supports_op(backend, node))
             ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
         else
             ggml_backend_sched_set_tensor_backend(sched, node, backend);
+    }
+
+    // Pass 2: assign virtual ops to the same backend as their next non-virtual consumer
+    for (int i = nodes - 1; i >= 0; --i) {
+        auto node = ggml_graph_node(gf, i);
+        if (!is_virtual(node->op))
+            continue;
+        ggml_backend_t target = backend;
+        for (int j = i + 1; j < nodes; ++j) {
+            auto next = ggml_graph_node(gf, j);
+            if (!is_virtual(next->op)) {
+                target = ggml_backend_sched_get_tensor_backend(sched, next);
+                break;
+            }
+        }
+        ggml_backend_sched_set_tensor_backend(sched, node, target ? target : backend);
     }
 }
 
@@ -212,7 +265,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
 
     auto feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len);
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
     ggml_backend_sched_synchronize(sched.get());
     ggml_backend_sched_alloc_graph(sched.get(), gf);
 
@@ -245,7 +298,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len, &t_leaf);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);
@@ -274,7 +327,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, static_cast<int>(flow.decoder.t_span.size() - 1), op_caps, cut_len, nullptr);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);


### PR DESCRIPTION
## Summary

- Per-op CPU fallback for Flow module via `ggml_backend_supports_op` — needed for backends lacking PAD/IM2COL support (e.g., Metal pre-M5)
- Original CUSTOM-only CPU fallback preserved for HiFT module — avoids cross-device pointer issues on discrete GPUs
- Extend `ggml_backend_op_capabilities` with `pad`, `pad_ext`, `pad_reflect_1d`, `im2col` flags (as proposed in #4)
- Fix `CausalConv1dBase` missing virtual destructor (undefined behavior on all platforms)

## Changes (2 commits)

| Commit | Files | Description |
|--------|-------|-------------|
| `feat: Metal per-op CPU fallback` | `cosyvoice-internal.h`, `cosyvoice-model.cpp`, `cosyvoice-tts.cpp`, `cosyvoice-modules.h` | Per-op routing for Flow; `op_caps` extension; virtual destructor fix |
| `fix: split routing` | `cosyvoice-tts.cpp` | Separate routing strategies — `set_graph_backend_per_op` (Flow) vs `set_graph_backend` (HiFT, CUSTOM-only, original logic) |

## Routing design

```
Flow graphs  → set_graph_backend_per_op()  — ggml_backend_supports_op per node
                                              Virtual ops follow consumer's backend
HiFT graph   → set_graph_backend()          — original CUSTOM-only CPU fallback
                                              All other ops + weights stay on GPU
```

## CUDA impact: none

On CUDA, `ggml_backend_supports_op` returns `true` for all ops. Both `set_graph_backend_per_op` and `set_graph_backend` assign everything to CUDA. **Behavior is identical to upstream on CUDA.**

## What this PR does NOT fix

- **CPU near-zero audio output**: Under investigation in #4 — Lourdle confirmed the issue originates in the Flow module, not HiFT
- **Metal inter-backend copy on pre-M5**: Filed upstream as ggml-org/llama.cpp#22085

## Related

- Issue: #4 (full investigation log)
- Supersedes: #2
- Upstream ggml issue: ggml-org/llama.cpp#22085

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>