### PR TITLE
cosyvoice: consolidate graph backend scheduling and op-capabilities

### DIFF
--- a/src/cosyvoice-internal.h
+++ b/src/cosyvoice-internal.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #if defined(_WIN32) && !defined(COSYVOICE_STATIC)
-	#define COSYVOICE_API __declspec(dllexport)
+    #define COSYVOICE_API __declspec(dllexport)
 #endif
 
 #include "cosyvoice.h"
@@ -14,64 +14,72 @@
 
 struct ggml_backend_op_capabilities
 {
-	bool concat_i32    : 1;
-	bool repeat_f16    : 1;
-	bool pad           : 1;
-	bool pad_ext       : 1;
-	bool pad_reflect_1d: 1;
-	bool im2col        : 1;
-	bool im2col_f16    : 1;
+    bool concat_i32    : 1;
+    bool repeat_f16    : 1;
+    bool pad           : 1;
+    bool pad_reflect_1d: 1;
+    bool im2col_f16    : 1;
 };
 
-struct cosyvoice_model;
+struct ggml_cgraph_node_iterator
+{
+    ggml_cgraph_node_iterator(ggml_cgraph* gf) : ggml_cgraph_node_iterator(gf, 0) {}
+    ggml_cgraph_node_iterator(ggml_cgraph* gf, int end) : nodes(ggml_graph_nodes(gf)), n_nodes(end > 0 ? end : ggml_graph_n_nodes(gf) + end) {}
+
+    ggml_tensor** begin() const { return nodes; }
+    ggml_tensor** end() const { return nodes + n_nodes; }
+
+    ggml_tensor** nodes;
+    int n_nodes;
+};
 
 struct matrix
 {
-	matrix() : shape{ 0, 0 }, stride(0), data(nullptr) {}
-	matrix(uint32_t dim0, uint32_t dim1) : shape{ dim0, dim1 }, stride(dim1), data(new float[dim0 * dim1]())
-	{
-		orig_data.reset(data);
-	}
+    matrix() : shape{ 0, 0 }, stride(0), data(nullptr) {}
+    matrix(uint32_t dim0, uint32_t dim1) : shape{ dim0, dim1 }, stride(dim1), data(new float[dim0 * dim1]())
+    {
+        orig_data.reset(data);
+    }
 
-	matrix operator[](uint32_t index) const
-	{
-		matrix result;
-		result.shape[0] = 1;
-		result.shape[1] = shape[1];
-		result.stride = stride;
+    matrix operator[](uint32_t index) const
+    {
+        matrix result;
+        result.shape[0] = 1;
+        result.shape[1] = shape[1];
+        result.stride = stride;
 
-		result.data = data + index * stride;
-		result.orig_data = orig_data;
-		return result;
-	}
+        result.data = data + index * stride;
+        result.orig_data = orig_data;
+        return result;
+    }
 
-	matrix slice(uint32_t start_dim0, uint32_t end_dim0, uint32_t start_dim1, uint32_t end_dim1) const
-	{
-		matrix result;
-		result.shape[0] = end_dim0 - start_dim0;
-		result.shape[1] = end_dim1 - start_dim1;
-		result.data = data + start_dim0 * stride + start_dim1;
-		result.stride = stride;
-		result.orig_data = orig_data;
-		return result;
-	}
+    matrix slice(uint32_t start_dim0, uint32_t end_dim0, uint32_t start_dim1, uint32_t end_dim1) const
+    {
+        matrix result;
+        result.shape[0] = end_dim0 - start_dim0;
+        result.shape[1] = end_dim1 - start_dim1;
+        result.data = data + start_dim0 * stride + start_dim1;
+        result.stride = stride;
+        result.orig_data = orig_data;
+        return result;
+    }
 
-	inline
-	float& operator()(uint32_t dim0, uint32_t dim1)
-	{
-		return data[dim0 * stride + dim1];
-	}
+    inline
+    float& operator()(uint32_t dim0, uint32_t dim1)
+    {
+        return data[dim0 * stride + dim1];
+    }
 
-	inline
-	const float& operator()(uint32_t dim0, uint32_t dim1) const
-	{
-		return data[dim0 * stride + dim1];
-	}
+    inline
+    const float& operator()(uint32_t dim0, uint32_t dim1) const
+    {
+        return data[dim0 * stride + dim1];
+    }
 
-	uint32_t shape[2];
-	size_t stride;
-	float* data;
-	std::shared_ptr<float[]> orig_data;
+    uint32_t shape[2];
+    size_t stride;
+    float* data;
+    std::shared_ptr<float[]> orig_data;
 };
 
 using tokens_t = std::pair<std::shared_ptr<int[]>, uint32_t>;
@@ -79,57 +87,57 @@ using text_t = std::pair<std::shared_ptr<char[]>, uint32_t>;
 
 struct cosyvoice_prompt_speech
 {
-	text_t text;
-	matrix feat;
-	matrix embedding;
-	tokens_t tokens;
-	uint32_t crc32;
+    text_t text;
+    matrix feat;
+    matrix embedding;
+    tokens_t tokens;
+    uint32_t crc32;
 
-	void calculate_crc32();
+    void calculate_crc32();
 };
 
 struct cosyvoice_prompt
 {
-	std::vector<int> prompt_text;
-	tokens_t orig_prompt_text;
-	tokens_t llm_prompt_speech_tokens;
-	tokens_t flow_prompt_speech_tokens;
-	matrix prompt_speech_feat;
-	matrix llm_embedding;
-	matrix flow_embedding;
+    std::vector<int> prompt_text;
+    tokens_t orig_prompt_text;
+    tokens_t llm_prompt_speech_tokens;
+    tokens_t flow_prompt_speech_tokens;
+    matrix prompt_speech_feat;
+    matrix llm_embedding;
+    matrix flow_embedding;
 
-	uint32_t prompt_crc32;
-	void calculate_crc32();
+    uint32_t prompt_crc32;
+    void calculate_crc32();
 };
 
 struct cosyvoice_tokenization_result_impl : cosyvoice_tokenization_result {
-	cosyvoice_tokenization_result_impl() {}
+    cosyvoice_tokenization_result_impl() {}
 
-	int* get_tokens() { return tokens.data(); }
-	uint32_t get_n_tokens() { return static_cast<uint32_t>(tokens.size()); }
+    int* get_tokens() { return tokens.data(); }
+    uint32_t get_n_tokens() { return static_cast<uint32_t>(tokens.size()); }
 
-	std::vector<int> tokens;
+    std::vector<int> tokens;
 };
 
 bool cosyvoice_frontend_util_text_normalize(
-	std::string& text,
-	const char* orig_text,
-	uint32_t text_len,
-	const char* locale
+    std::string& text,
+    const char* orig_text,
+    uint32_t text_len,
+    const char* locale
 );
 
 int cosyvoice_llm_sampler(
-	cosyvoice_llm_token_prob_t* nucleus_probs,
-	int k,
-	float* probs,
-	uint32_t size,
-	const cosyvoice_sampling_params_t* sampling_params,
-	int* accepted_tokens,
-	uint32_t n_accepted_tokens,
-	std::mt19937* rng
+    cosyvoice_llm_token_prob_t* nucleus_probs,
+    int k,
+    float* probs,
+    uint32_t size,
+    const cosyvoice_sampling_params_t* sampling_params,
+    int* accepted_tokens,
+    uint32_t n_accepted_tokens,
+    std::mt19937* rng
 );
 
 void cosyvoice_call_ggml_log_callback(
-	ggml_log_level level,
-	const char* message
+    ggml_log_level level,
+    const char* message
 );

--- a/src/cosyvoice-llm.cpp
+++ b/src/cosyvoice-llm.cpp
@@ -80,12 +80,8 @@ static ggml_tensor* build_qwen2_decoder_layer(const Qwen2DecoderLayer& layer, gg
 
 static void set_graph_backend(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend)
 {
-    int nodes = ggml_graph_n_nodes(gf);
-
-    for (int i = 0; i != nodes; ++i) {
-        auto node = ggml_graph_node(gf, i);
+    for (auto node : ggml_cgraph_node_iterator(gf))
         ggml_backend_sched_set_tensor_backend(sched, node, backend);
-    }
 }
 
 bool cosyvoice_model_3::llm_prefill(

--- a/src/cosyvoice-model.cpp
+++ b/src/cosyvoice-model.cpp
@@ -57,20 +57,9 @@ cosyvoice_model::cosyvoice_model(ggml_backend_t backend, const cosyvoice_context
     a = ggml_pad(ctx0.get(), a, 4, 0, 0, 0);
     op_caps.pad = ggml_backend_supports_op(backend, a);
 
-    a = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 16, 4, 1);
-    a = ggml_pad_ext(ctx0.get(), a, 2, 0, 0, 0, 0, 0, 0, 0);
-    op_caps.pad_ext = ggml_backend_supports_op(backend, a);
-
     a = ggml_new_tensor_1d(ctx0.get(), GGML_TYPE_F32, 16);
     a = ggml_pad_reflect_1d(ctx0.get(), a, 1, 0);
     op_caps.pad_reflect_1d = ggml_backend_supports_op(backend, a);
-
-    {
-        ggml_tensor* w = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 3, 4, 8);
-        a = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F32, 16, 4, 1);
-        a = ggml_im2col(ctx0.get(), w, a, 1, 0, 0, 0, 1, 0, false, GGML_TYPE_F32);
-        op_caps.im2col = ggml_backend_supports_op(backend, a);
-    }
 
     {
         ggml_tensor* w = ggml_new_tensor_3d(ctx0.get(), GGML_TYPE_F16, 3, 4, 8);

--- a/src/cosyvoice-tts.cpp
+++ b/src/cosyvoice-tts.cpp
@@ -154,70 +154,33 @@ bool cosyvoice_model_3::llm_job(const int* text, uint32_t text_len, cosyvoice_pr
     return true;
 }
 
-// Route CUSTOM ops (and their trailing VIEW/PERMUTE) to CPU, everything else to GPU.
-// Used for HiFT where only FFT/ISTFT custom ops need CPU — all other ops and weights stay on GPU.
-static void set_graph_backend(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend, ggml_backend_t cpu_backend, int nodes = -1)
+static void set_graph_backends(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend, ggml_backend_t cpu_backend, ggml_backend_op_capabilities op_caps, int end = 0)
 {
-    if (nodes < 0)
-        nodes = ggml_graph_n_nodes(gf);
-
-    for (int i = 0; i != nodes; ++i) {
-        auto node = ggml_graph_node(gf, i);
-        if (node->op == GGML_OP_CUSTOM)
-        {
-            do {
-                ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
-                if (++i == nodes) return;
-                node = ggml_graph_node(gf, i);
-            } while ((node->op == GGML_OP_VIEW || node->op == GGML_OP_PERMUTE));
-
-            goto set_main_backend;
-        }
-        else
-        {
-        set_main_backend:
-            ggml_backend_sched_set_tensor_backend(sched, node, backend);
-        }
-    }
-}
-
-// Route unsupported ops to CPU based on ggml_backend_supports_op.
-// Used for Flow where PAD/IM2COL may be unsupported on some backends (e.g., Metal pre-M5).
-// Virtual ops (VIEW, RESHAPE, PERMUTE, TRANSPOSE) follow their consumer's backend.
-static void set_graph_backend_per_op(ggml_cgraph* gf, ggml_backend_sched_t sched, ggml_backend_t backend, ggml_backend_t cpu_backend, int nodes = -1)
-{
-    if (nodes < 0)
-        nodes = ggml_graph_n_nodes(gf);
-
     auto is_virtual = [](ggml_op op) {
         return op == GGML_OP_VIEW || op == GGML_OP_RESHAPE || op == GGML_OP_PERMUTE || op == GGML_OP_TRANSPOSE;
     };
 
-    // Pass 1: assign non-virtual ops based on supports_op
-    for (int i = 0; i != nodes; ++i) {
-        auto node = ggml_graph_node(gf, i);
-        if (is_virtual(node->op))
+    auto target_backend = backend;
+    for (auto node : ggml_cgraph_node_iterator(gf, end))
+    {
+        if (node->buffer)
             continue;
-        if (cpu_backend && !ggml_backend_supports_op(backend, node))
-            ggml_backend_sched_set_tensor_backend(sched, node, cpu_backend);
-        else
-            ggml_backend_sched_set_tensor_backend(sched, node, backend);
-    }
-
-    // Pass 2: assign virtual ops to the same backend as their next non-virtual consumer
-    for (int i = nodes - 1; i >= 0; --i) {
-        auto node = ggml_graph_node(gf, i);
-        if (!is_virtual(node->op))
-            continue;
-        ggml_backend_t target = backend;
-        for (int j = i + 1; j < nodes; ++j) {
-            auto next = ggml_graph_node(gf, j);
-            if (!is_virtual(next->op)) {
-                target = ggml_backend_sched_get_tensor_backend(sched, next);
+        else if (!is_virtual(node->op))
+            switch (node->op)
+            {
+            case GGML_OP_CUSTOM:
+                target_backend = cpu_backend;
                 break;
+            case GGML_OP_PAD:
+                target_backend = op_caps.pad ? backend : cpu_backend;
+                break;
+            case GGML_OP_PAD_REFLECT_1D:
+                target_backend = op_caps.pad_reflect_1d ? backend : cpu_backend;
+                break;
+            default:
+                target_backend = backend;
             }
-        }
-        ggml_backend_sched_set_tensor_backend(sched, node, target ? target : backend);
+        ggml_backend_sched_set_tensor_backend(sched, node, target_backend);
     }
 }
 
@@ -265,7 +228,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
 
     auto feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len);
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backends(gf, sched.get(), backend.get(), cpu_backend.get(), op_caps);
     ggml_backend_sched_synchronize(sched.get());
     ggml_backend_sched_alloc_graph(sched.get(), gf);
 
@@ -295,10 +258,10 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     ggml_reset(ctx0.get());
     ggml_backend_sched_reset(sched.get());
     gf = ggml_new_graph(ctx0.get());
-    feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 1, op_caps, cut_len, &t_leaf);
+    feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, 2, op_caps, cut_len, &t_leaf);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backends(gf, sched.get(), backend.get(), cpu_backend.get(), op_caps);
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);
@@ -327,7 +290,7 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
     feat = flow.decoder.build_cgraph_one_step(ctx0.get(), ditctx, static_cast<int>(flow.decoder.t_span.size() - 1), op_caps, cut_len, nullptr);
 
     ggml_build_forward_expand(gf, feat);
-    set_graph_backend_per_op(gf, sched.get(), backend.get(), cpu_backend.get());
+    set_graph_backends(gf, sched.get(), backend.get(), cpu_backend.get(), op_caps);
 
     ggml_backend_sched_alloc_graph(sched.get(), gf);
     status = ggml_backend_sched_graph_compute(sched.get(), gf);
@@ -344,21 +307,20 @@ bool cosyvoice_model_3::token2wav(const int* token_ids, uint32_t n_tokens, float
 
     if (std::abs(speed - 1.f) > FLT_EPSILON)
         speech_feat = ggml_interpolate(ctx0.get(), speech_feat,
-            static_cast<int64_t>(feat->ne[0] / speed), feat->ne[1], feat->ne[2], feat->ne[3],
+            static_cast<int64_t>(speech_feat->ne[0] / speed), speech_feat->ne[1], speech_feat->ne[2], speech_feat->ne[3],
             GGML_SCALE_MODE_BILINEAR);
 
     auto [generated_speech, noise] = hift.build_cgraph(ctx0.get(), speech_feat);
     ggml_build_forward_expand(gf, generated_speech);
-    set_graph_backend(gf, sched.get(), backend.get(), cpu_backend.get(), ggml_graph_n_nodes(gf) - 1);
+    set_graph_backends(gf, sched.get(), backend.get(), cpu_backend.get(), op_caps, -1);
 
     ggml_backend_sched_set_tensor_backend(sched.get(), generated_speech, cpu_backend.get());
     ggml_backend_sched_alloc_graph(sched.get(), gf);
-    for (int i = 0; i != ggml_graph_n_nodes(gf); ++i)
-    {
-        auto node = ggml_graph_node(gf, i);
+
+    for (auto node : ggml_cgraph_node_iterator(gf))
         if (node->op == GGML_OP_IM2COL && node->ne[1] > 0xFFFF)
             node->op = GGML_OP_NONE;
-    }
+
     noise_len = static_cast<uint32_t>(ggml_nelements(noise));
     noise_buffer = noise_callback(COSYVOICE_NOISE_CALLBACK_STAGE_BEFORE_HIFT, noise_len, nullptr, noise_callback_ctx);
     ggml_backend_tensor_set_async(backend.get(), noise, noise_buffer, 0, noise->nb[2]);


### PR DESCRIPTION
This pull request refactors backend assignment logic for graph nodes in the CosyVoice codebase, improving maintainability and consistency. The main changes include consolidating and simplifying the logic for assigning tensor backends in computation graphs, removing support checks for certain operations, and introducing a new iterator for graph nodes. These updates streamline how backends are chosen for each operation.

**Backend assignment refactoring:**

* Consolidated the per-operation and custom-op backend assignment logic into a single function, `set_graph_backends`, which now uses a new `ggml_cgraph_node_iterator` for cleaner iteration over graph nodes and makes backend assignment more maintainable and extensible.

**Graph node iteration improvements:**

* Introduced the `ggml_cgraph_node_iterator` struct in `cosyvoice-internal.h` to provide a convenient and type-safe way to iterate over graph nodes, replacing manual index-based loops.