### PR TITLE
fix: prevent SIGABRT on long text input via graceful failure and chunked synthesis

### DIFF
--- a/src/cosyvoice-llm.cpp
+++ b/src/cosyvoice-llm.cpp
@@ -91,8 +91,8 @@ bool cosyvoice_model_3::llm_prefill(
 )
 {
     auto total_len = n_tokens + kv_cache->cur_len;
-    GGML_ASSERT(total_len <= params.n_max_seq - 1);
-    GGML_ASSERT(n_tokens <= params.n_batch);
+    if (total_len > params.n_max_seq - 1) return false;
+    if (n_tokens > params.n_batch) return false;
 
     auto causal_mask = n_tokens == 1 ? nullptr : this->causal_mask;
     if (causal_mask)
@@ -188,7 +188,7 @@ bool cosyvoice_model_3::llm_prefill(
 
 bool cosyvoice_model_3::llm_decode(ggml_type type, const void* data)
 {
-    GGML_ASSERT(kv_cache->cur_len + 1 <= params.n_max_seq);
+    if (kv_cache->cur_len + 1 > params.n_max_seq) return false;
 
     position_ids->ne[0] = 1;
     ggml_backend_tensor_set_async(backend.get(), position_ids, full_position_ids.get() + kv_cache->cur_len, 0, sizeof(int32_t));

--- a/src/cosyvoice.cpp
+++ b/src/cosyvoice.cpp
@@ -232,6 +232,26 @@ bool cosyvoice_token2wav(cosyvoice_context_t ctx, const int* token_ids, uint32_t
 
 bool cosyvoice_tts(cosyvoice_context_t ctx, const int* text, uint32_t text_len, float speed, cosyvoice_prompt_t prompt, cosyvoice_generated_speech_ptr result)
 {
+    // Defensive guard: bail out before llm_prefill / llm_decode would refuse the request because
+    // the prefill layout exceeds n_max_seq. Without this, llm_job throws and emits an error log
+    // for every doomed call; rejecting up-front lets the caller know the input is too long.
+    cosyvoice_context_params_t params;
+    ctx->get_context_params(&params);
+    const uint32_t kv_cache_len = ctx->llm_get_kv_cache_len();
+    const uint32_t prompt_text_len = static_cast<uint32_t>(prompt->prompt_text.size());
+    const uint32_t prompt_speech_len = prompt->llm_prompt_speech_tokens.second;
+    // Worst-case prefill: SOS(1) + prompt_text + text + (task_token(1) + prompt_speech_tokens) when present.
+    uint64_t prefill_len = 1ull + prompt_text_len + text_len;
+    if (prompt_speech_len != 0)
+        prefill_len += 1ull + prompt_speech_len;
+    const uint64_t budget = std::max<uint64_t>(kv_cache_len, prefill_len);
+    if (budget + 1 > params.n_max_seq)
+    {
+        result->data = nullptr;
+        result->length = 0;
+        return false;
+    }
+
     if(ctx->llm_job(text, text_len, prompt)
         && ctx->token2wav(ctx->llm_get_accepted_tokens(), ctx->llm_get_n_accepted_tokens(), speed, prompt, result))
         return true;

--- a/tools/cli/cosyvoice-cli.cpp
+++ b/tools/cli/cosyvoice-cli.cpp
@@ -3,6 +3,7 @@
 #endif
 
 #include "tool_common_cosyvoice.h"
+#include "cosyvoice-text-chunk.h"
 
 #ifdef COSYVOICE_NO_AUDIO
     #define cosyvoice_audio_save_to_file cosyvoice_save_wav
@@ -23,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 #include <format>
 
 struct cli_options
@@ -1170,18 +1172,34 @@ int tool_entry(int argc, char** argv)
     cosyvoice_get_memory_usage(ctx.get(), &memory_usage_before);
     print_tts_runtime_info(options, backend, effective_params, generation_config, sample_rate, log_level);
 
-    cosyvoice_generated_speech result = {};
+    auto text_chunks = cosyvoice_common::split_text_into_chunks(options.text);
+    if (text_chunks.empty())
+        text_chunks.emplace_back(options.text);
+
+    std::vector<float> combined_pcm;
     stage_start = std::chrono::steady_clock::now();
-    bool ok = false;
-    if (options.mode == "cross-lingual")
-        ok = cosyvoice_tts_cross_lingual(tts_ctx.get(), options.text.c_str(), options.speed, &result);
-    else if (options.mode == "zero-shot")
-        ok = cosyvoice_tts_zero_shot(tts_ctx.get(), options.text.c_str(), options.speed, &result);
-    else
-        ok = cosyvoice_tts_instruct(tts_ctx.get(), options.text.c_str(), options.instruction.c_str(), options.speed, &result);
+    bool ok = true;
+    for (const auto& chunk : text_chunks)
+    {
+        cosyvoice_generated_speech part = {};
+        bool part_ok = false;
+        if (options.mode == "cross-lingual")
+            part_ok = cosyvoice_tts_cross_lingual(tts_ctx.get(), chunk.c_str(), options.speed, &part);
+        else if (options.mode == "zero-shot")
+            part_ok = cosyvoice_tts_zero_shot(tts_ctx.get(), chunk.c_str(), options.speed, &part);
+        else
+            part_ok = cosyvoice_tts_instruct(tts_ctx.get(), chunk.c_str(), options.instruction.c_str(), options.speed, &part);
+
+        if (!part_ok || !part.data || part.length == 0)
+        {
+            ok = false;
+            break;
+        }
+        combined_pcm.insert(combined_pcm.end(), part.data, part.data + part.length);
+    }
     timing.tts_generate_ms = elapsed_ms(stage_start, std::chrono::steady_clock::now());
 
-    if (!ok && (!result.data || result.length == 0))
+    if (!ok || combined_pcm.empty())
     {
         print_error_log("Error: TTS generation failed.\n");
         return 1;
@@ -1191,7 +1209,7 @@ int tool_entry(int argc, char** argv)
     print_memory_runtime_info(memory_usage_before, memory_usage_after, log_level);
 
     stage_start = std::chrono::steady_clock::now();
-    if (!cosyvoice_audio_save_to_file(options.output.c_str(), result.data, result.length, sample_rate))
+    if (!cosyvoice_audio_save_to_file(options.output.c_str(), combined_pcm.data(), static_cast<uint32_t>(combined_pcm.size()), sample_rate))
     {
         print_error_log("Error: failed to save output audio file \"%s\".\n", options.output.c_str());
         return 1;

--- a/tools/common/CMakeLists.txt
+++ b/tools/common/CMakeLists.txt
@@ -1,3 +1,8 @@
-add_library(tools_common STATIC common.cpp tool_common.h tool_common_cosyvoice.h)
+add_library(tools_common STATIC
+    common.cpp
+    cosyvoice-text-chunk.cpp
+    cosyvoice-text-chunk.h
+    tool_common.h
+    tool_common_cosyvoice.h)
 target_include_directories(tools_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}/common")
 target_link_libraries(tools_common PRIVATE common)

--- a/tools/common/cosyvoice-text-chunk.cpp
+++ b/tools/common/cosyvoice-text-chunk.cpp
@@ -1,0 +1,118 @@
+#include "cosyvoice-text-chunk.h"
+
+#include <array>
+#include <cstring>
+
+namespace cosyvoice_common {
+namespace {
+
+constexpr std::array<std::string_view, 7> hard_enders = {
+    "\n", ".", "?", "!", "\xE3\x80\x82", "\xEF\xBC\x9F", "\xEF\xBC\x81",
+    // U+3002 IDEOGRAPHIC FULL STOP "。"
+    // U+FF1F FULLWIDTH QUESTION MARK "？"
+    // U+FF01 FULLWIDTH EXCLAMATION MARK "！"
+};
+
+constexpr std::array<std::string_view, 5> soft_seps = {
+    ",", ";", ":", "\xE3\x80\x81", "\xEF\xBC\x9B",
+    // U+3001 IDEOGRAPHIC COMMA "、"
+    // U+FF1B FULLWIDTH SEMICOLON "；"
+};
+
+inline std::size_t utf8_char_len(unsigned char b)
+{
+    if ((b & 0x80) == 0x00) return 1;
+    if ((b & 0xE0) == 0xC0) return 2;
+    if ((b & 0xF0) == 0xE0) return 3;
+    if ((b & 0xF8) == 0xF0) return 4;
+    return 1;  // invalid byte; advance by one to avoid getting stuck
+}
+
+inline bool match_at(std::string_view text, std::size_t pos, std::string_view pattern)
+{
+    return pos + pattern.size() <= text.size()
+        && std::memcmp(text.data() + pos, pattern.data(), pattern.size()) == 0;
+}
+
+inline bool is_ws(char c) { return c == ' ' || c == '\t' || c == '\n' || c == '\r'; }
+
+inline void emit_trimmed(std::vector<std::string>& chunks, std::string_view text, std::size_t lo, std::size_t hi)
+{
+    while (lo < hi && is_ws(text[lo])) ++lo;
+    while (hi > lo && is_ws(text[hi - 1])) --hi;
+    if (lo < hi)
+        chunks.emplace_back(text.substr(lo, hi - lo));
+}
+
+}  // namespace
+
+std::vector<std::string> split_text_into_chunks(std::string_view text, std::size_t max_bytes)
+{
+    std::vector<std::string> chunks;
+    if (text.empty())
+        return chunks;
+    if (max_bytes == 0)
+        max_bytes = default_max_chunk_bytes;
+
+    std::size_t start = 0;
+    std::size_t last_soft = 0;  // byte position right after the most recent soft separator
+    std::size_t i = 0;
+    while (i < text.size())
+    {
+        bool matched = false;
+
+        for (const auto& ender : hard_enders)
+        {
+            if (match_at(text, i, ender))
+            {
+                const auto end = i + ender.size();
+                emit_trimmed(chunks, text, start, end);
+                start = end;
+                last_soft = 0;
+                i = end;
+                matched = true;
+                break;
+            }
+        }
+        if (matched) continue;
+
+        for (const auto& sep : soft_seps)
+        {
+            if (match_at(text, i, sep))
+            {
+                i += sep.size();
+                last_soft = i;
+                if (i - start >= max_bytes)
+                {
+                    emit_trimmed(chunks, text, start, last_soft);
+                    start = last_soft;
+                    last_soft = 0;
+                }
+                matched = true;
+                break;
+            }
+        }
+        if (matched) continue;
+
+        i += utf8_char_len(static_cast<unsigned char>(text[i]));
+
+        if (i - start >= max_bytes)
+        {
+            std::size_t cut = (last_soft > start) ? last_soft : i;
+            while (cut > start && cut < text.size()
+                && (static_cast<unsigned char>(text[cut]) & 0xC0) == 0x80)
+                --cut;
+            if (cut <= start) cut = i;
+            emit_trimmed(chunks, text, start, cut);
+            start = cut;
+            last_soft = 0;
+        }
+    }
+
+    if (start < text.size())
+        emit_trimmed(chunks, text, start, text.size());
+
+    return chunks;
+}
+
+}  // namespace cosyvoice_common

--- a/tools/common/cosyvoice-text-chunk.h
+++ b/tools/common/cosyvoice-text-chunk.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cosyvoice_common {
+
+// Default chunk-size budget in bytes. CosyVoice's LLM has n_max_seq=2048 by default; the KV cache,
+// reference-audio prompt tokens and the speech tokens decoded from the input all share that budget.
+// 600 bytes leaves room for ~200 kana or ~150 mixed CJK characters per chunk while staying clear of
+// the assertion in llm_prefill that previously aborted on long input.
+inline constexpr std::size_t default_max_chunk_bytes = 600;
+
+// Split UTF-8 text into chunks suitable for sequential TTS calls.
+//
+// - Splits at hard sentence enders (".", "?", "!", "\n", and their full-width counterparts) whenever
+//   they appear, regardless of chunk size.
+// - When no sentence end is reached and the running chunk exceeds `max_bytes`, falls back to the most
+//   recent soft separator (",", ";", ":", "、", "；").
+// - If no separator is available, force-splits at a UTF-8 code-point boundary so multi-byte sequences
+//   are never cut in half.
+// - Whitespace-only fragments are dropped.
+std::vector<std::string> split_text_into_chunks(
+    std::string_view text,
+    std::size_t max_bytes = default_max_chunk_bytes);
+
+}  // namespace cosyvoice_common

--- a/tools/server/cosyvoice-server-backend.cpp
+++ b/tools/server/cosyvoice-server-backend.cpp
@@ -1,5 +1,6 @@
 ﻿#include "cosyvoice-server.h"
 #include "tool_common_cosyvoice.h"
+#include "cosyvoice-text-chunk.h"
 
 #ifndef COSYVOICE_NO_AUDIO
     #include "cosyvoice-audio.h"
@@ -1033,6 +1034,7 @@ int cosyvoice_server_backend_run(server_runtime& runtime)
         }
 
         cosyvoice_generated_speech generated = {};
+        std::vector<float> combined_pcm;
         std::string payload;
         std::string encoding_error;
         std::string generation_error;
@@ -1047,18 +1049,37 @@ int cosyvoice_server_backend_run(server_runtime& runtime)
                 return;
             }
 
-            bool ok = false;
-            if (request.has_instructions)
-                ok = cosyvoice_tts_instruct(voice_it->second.tts_context.get(), request.input.c_str(), request.instructions.c_str(), request.speed, &generated);
-            else
-                ok = cosyvoice_tts_zero_shot(voice_it->second.tts_context.get(), request.input.c_str(), request.speed, &generated);
+            auto text_chunks = cosyvoice_common::split_text_into_chunks(request.input);
+            if (text_chunks.empty())
+                text_chunks.emplace_back(request.input);
 
-            if (!ok || !generated.data || generated.length == 0)
+            bool ok = true;
+            for (const auto& chunk : text_chunks)
+            {
+                cosyvoice_generated_speech part = {};
+                bool part_ok = false;
+                if (request.has_instructions)
+                    part_ok = cosyvoice_tts_instruct(voice_it->second.tts_context.get(), chunk.c_str(), request.instructions.c_str(), request.speed, &part);
+                else
+                    part_ok = cosyvoice_tts_zero_shot(voice_it->second.tts_context.get(), chunk.c_str(), request.speed, &part);
+
+                if (!part_ok || !part.data || part.length == 0)
+                {
+                    ok = false;
+                    break;
+                }
+                combined_pcm.insert(combined_pcm.end(), part.data, part.data + part.length);
+            }
+
+            if (!ok || combined_pcm.empty())
             {
                 set_openai_error(res, 500, "TTS generation failed.", "server_error", nullptr, "generation_failed");
                 log_request_done(runtime.log_level, log_ctx, request_log_status::failed, res.status, applied_seed, res.body.size(), "generation_failed");
                 return;
             }
+
+            generated.data = combined_pcm.data();
+            generated.length = static_cast<uint32_t>(combined_pcm.size());
 
             if (!build_audio_payload(format, generated, runtime, &payload, &encoding_error))
             {


### PR DESCRIPTION
## Summary

- Replace `GGML_ASSERT` in `llm_prefill` / `llm_decode` with graceful `return false` for sequence overflow, so library users get an error instead of process termination.
- Add a defensive length guard at `cosyvoice_tts()` entry to short-circuit doomed calls before the LLM stage logs an error per chunk.
- Add a small UTF-8-aware text chunk splitter under `tools/common/` and use it in the CLI and server so end users automatically split long input at sentence/clause boundaries.

## Background

On builds prior to `cosyvoice: add CPU tensor flag mechanism` (9710b7d), long text input (e.g. kana ~950 chars with a non-trivial reference-audio prompt) tripped the `GGML_ASSERT(total_len <= params.n_max_seq - 1)` check inside `cosyvoice_model_3::llm_prefill`, producing a SIGABRT that crashed the host process. While the new CPU/STFT changes relax the practical limit for many inputs, the underlying assertion can still trigger when a configured `n_max_seq` is exceeded and there is no safe way for an embedder to recover. This PR turns those assertions into recoverable failures and offers a server/CLI-side splitter so typical long inputs no longer reach the limit at all.

## Test plan

- [x] Local build of `cosyvoice` + `cosyvoice-cli` + `cosyvoice-server` + `tools_common` succeeds with no new warnings.
- [x] Live run via an FFI consumer of `libcosyvoice.dylib` returns HTTP 200 for kana inputs of 950 / 1969 / 2852 chars without aborting (linear ~0.39s synthesis time per char).
- [x] CLI/server `/v1/audio/speech` paths apply the new splitter to the request input before invoking `cosyvoice_tts_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)