### PR TITLE
Fix off-by-one in the DiT graph-reuse Euler step

### DIFF
--- a/src/cosyvoice-token2wav.cpp
+++ b/src/cosyvoice-token2wav.cpp
@@ -366,7 +366,8 @@ bool cosyvoice_model_3::token2wav_ext(const int* token_ids, uint32_t n_tokens, f
         {
             auto scale_node = feat->src[1];
             GGML_ASSERT(scale_node->op == GGML_OP_SCALE);
-            auto [t, dt] = flow.decoder.get_t_and_dt(ctx0.get(), step);
+            // Match the rebuild branch, which advances this iteration to step + 1.
+            auto [t, dt] = flow.decoder.get_t_and_dt(ctx0.get(), step + 1);
             reinterpret_cast<float*>(t_leaf->op_params)[op_caps.fill ? 0 : 1] = t;
             reinterpret_cast<float*>(scale_node->op_params)[0] = dt;
 


### PR DESCRIPTION
## Summary

Advance the DiT graph-reuse branch to Euler step `step + 1`, matching the
graph-rebuild branch for the same sampling-loop iteration.

```diff
             auto scale_node = feat->src[1];
             GGML_ASSERT(scale_node->op == GGML_OP_SCALE);
-            auto [t, dt] = flow.decoder.get_t_and_dt(ctx0.get(), step);
+            // Advance the reused graph to Euler step `step + 1`, matching the
+            // rebuild path above (build_cgraph_one_step(..., step + 1, ...)).
+            auto [t, dt] = flow.decoder.get_t_and_dt(ctx0.get(), step + 1);
```

## Problem

`get_t_and_dt()` uses a 1-based Euler-step index. Euler step `k` evaluates at
`t_span[k - 1]` and applies:

```text
dt = t_span[k] - t_span[k - 1]
```

The rebuild branch already builds the current iteration with `step + 1`, but
the reuse branch requests `step`. A reuse iteration therefore applies the
previous Euler interval.

With the default 10-step configuration, the current code executes:

```text
1, 2, 2, 3, 4, 5, 6, 7, 8, 10
```

Step 2 is duplicated, step 9 is skipped, and step 10 is still executed. The
applied step sizes sum to `0.884049236` instead of 1, leaving the solver state
inconsistent with the time supplied to the final estimator call.

After this change, the sequence is:

```text
1, 2, 3, 4, 5, 6, 7, 8, 9, 10
```

and the step sizes sum to 1 within float32 precision.

## Testing

Reproduced against upstream commit
`22da72424da89f74b90623ed164c22e68bc902ad` using:

- `Fun-CosyVoice3-0.5B-2512` Q8_0 GGUF
- CUDA on an RTX 3090
- default 10 flow-matching steps
- non-streaming inference
- default `--dit-kv-*-slots 0`

Runtime instrumentation recorded the branch and actual `(euler_step, t, dt)`
used by every iteration:

| Build | Executed Euler steps | Sum of applied `dt` |
|---|---|---:|
| Current main | `1 2 2 3 4 5 6 7 8 10` | `0.884049236` |
| Patched | `1 2 3 4 5 6 7 8 9 10` | `0.999999999` |

Schedule probes for 4, 6, and 10 steps likewise pass after the fix with no
duplicate or missing intervals.

Three paired, fixed-seed smoke-test utterances confirmed that this one-line
change affects real generated audio. Mean UTMOS changed from `3.1179` to
`3.3084`, but one of the three samples decreased, so this PR treats the trace
as the correctness proof and makes no claim about a guaranteed perceptual
quality improvement.

## Scope

This change only corrects the Euler index used while reusing a DiT graph. It
does not change the timestep schedule, the number of flow steps, KV-slot
configuration, streaming behavior, or model format.

For reference, the official `QwenAudio/CosyVoice` Python implementation was
also tested with its released `flow.pt`: 4, 6, and 10 requested steps produced
exactly 4, 6, and 10 estimator calls with `sum(dt) = 1.0`. The defect is
specific to this C++ graph-reuse path.