### PR TITLE
Read chunk_tokens inside the streaming loop

### DIFF
--- a/src/cosyvoice.cpp
+++ b/src/cosyvoice.cpp
@@ -430,13 +430,13 @@ bool cosyvoice_tts_stream(cosyvoice_context_t ctx, const int* text, uint32_t tex
     {
         use_count_guard guard(ctx);
 
-        const auto chunk_tokens = ctx->get_chunk_tokens();
-
         ctx->llm_clear_accepted_tokens();
         uint32_t n_tokens = 0;
         bool final = false;
         do
         {
+            const auto chunk_tokens = ctx->get_chunk_tokens();
+
             if (ctx->is_stop_requested())
                 return false;
 


### PR DESCRIPTION
## 修复流式合成过程中修改 chunk_tokens 不生效的问题
## Summary

`cosyvoice_tts_stream()` currently reads `chunk_tokens` once before entering the
streaming loop. As a result, calling `cosyvoice_set_chunk_tokens()` from a stream
callback updates the context and the public getter immediately, but the active stream
continues using the old value until the utterance ends.

Read `chunk_tokens` at the start of each loop iteration so a runtime update takes effect
on the next chunk.

```diff
-        const auto chunk_tokens = ctx->get_chunk_tokens();
-
         ctx->llm_clear_accepted_tokens();
         uint32_t n_tokens = 0;
         bool final = false;
         do
         {
+            const auto chunk_tokens = ctx->get_chunk_tokens();
+
             if (ctx->is_stop_requested())
                 return false;
```

## Why

Before this change, a mid-stream setter call creates inconsistent observable state:

- `cosyvoice_get_chunk_tokens()` reports the new value;
- `llm_job_ext()` and the `n_tokens` advance continue using the stale snapshot;
- the requested update is silently deferred until the next utterance.

Other mutable generation settings are read at their point of use. For example,
`cosyvoice_set_generation_config()` affects the next `llm_job_ext()` call. Re-reading
`chunk_tokens` per iteration gives this runtime setter matching semantics.

`chunk_tokens` is the stride used to request and expose the next cumulative token
position. Changing the stride does not invalidate previously generated tokens, and the
existing `std::min(..., accepted_tokens)` bound remains in place.

## Testing

- CUDA / RTX 3090 / Q8_0: changed `chunk_tokens` from 25 to 10 during the stream.
  Before the fix, the getter changed to 10 while the loop continued using 25 and regular
  chunks remained 1000 ms. After the fix, the next iteration used 10 and regular chunks
  became 400 ms.
- CUDA control: without a setter call, before/after output was byte-identical
  (`0d0f28e4a0039ada95ffe400fba8722f`, 681600 samples).
- CUDA control: a mid-stream `cosyvoice_set_generation_config()` call behaved identically
  before and after this patch.
- Apple M5 / Metal / Q4_K_M: verified both 25 -> 15 and 15 -> 25 updates. The loop/getter
  mismatch count changed from 11/19 before the fix to 0/0 after it; all streams completed
  successfully.
- Apple M5 control: without a setter call, before/after output was identical (12 callbacks,
  263040 samples, hash `1aaab39e078bab83`).

The Apple build used an isolated Apple Clang template-argument compatibility workaround
that does not touch this code path and is intentionally excluded from this PR.

## Alternative semantics

If `chunk_tokens` is intentionally fixed for an entire utterance, the API should instead
document that the setter is deferred and avoid having the getter report a value that the
active stream is not using. The current setter/getter behavior does not communicate that
contract.
