### PR TITLE
Fix Apple Clang build for the DiT schedule template argument

### DIFF
--- a/src/cosyvoice-token2wav.cpp
+++ b/src/cosyvoice-token2wav.cpp
@@ -228,7 +228,7 @@ bool cosyvoice_model_3::token2wav_ext(const int* token_ids, uint32_t n_tokens, f
         }
     } while (false);
 
-    dit_sched_config<flow.decoder.diffusion_steps> config(params, cut_len, streaming ? worker->offset : 0, streaming, kv_cache->can_reuse());
+    dit_sched_config<CausalConditionalCFM::diffusion_steps> config(params, cut_len, streaming ? worker->offset : 0, streaming, kv_cache->can_reuse());
     uint32_t noise_len = static_cast<uint32_t>(ggml_nelements(ditctx.x));
     uint32_t noise_req = noise_len;
     int64_t full_len;


### PR DESCRIPTION
## Summary

Apple Clang 17 rejects the `dit_sched_config` instantiation in
`cosyvoice_model_3::token2wav_ext()` because its non-type template argument is
written through the non-constant `flow` object:

```text
error: non-type template argument is not a constant expression
note: initializer of 'flow' is not a constant expression
```

Refer to the static constant through its declaring type instead:

```diff
-    dit_sched_config<flow.decoder.diffusion_steps> config(...);
+    dit_sched_config<CausalConditionalCFM::diffusion_steps> config(...);
```

`CausalConditionalCFM::diffusion_steps` is already declared as
`constexpr static int` and is also referenced by type in `cosyvoice-loader.cpp`.
This is a compile-only portability change; the template value remains 10 and runtime
behavior is unchanged.

## Scope

This failure is unrelated to streaming `chunk_tokens` behavior. This PR contains only the
compile-time portability fix and does not change the DiT schedule or runtime behavior.

The macOS release workflow currently selects Homebrew LLVM 20 explicitly. A user building
with the default Xcode command-line tools instead gets Apple Clang, so this compiler path
is not covered by the existing macOS CI configuration.

## Testing

- Reproduced on upstream `aa423b1340b1efe037f010f882e7f9b21e2f77cd` with Apple
  Clang 17.0.0 (`clang-1700.6.3.2`). The failing expression is unchanged on current
  `main` (`9d45b1ec58e7b6ef9ed8f98cd42e5ae0ac76a8ee`, after #27).
- After applying this one-line change, the same source tree builds successfully on Apple
  M5 / macOS 26.3 / arm64 with Metal enabled.
- Runtime smoke test: completed streaming inference with a Q4_K_M model; both increasing
  and decreasing chunk-size cases returned successfully.

Build configuration:

```text
-DCMAKE_BUILD_TYPE=Release
-DCMAKE_OSX_ARCHITECTURES=arm64
-DCOSYVOICE_NO_FRONTEND=ON
-DCOSYVOICE_NO_ICU=ON
-DCOSYVOICE_NO_AUDIO=ON
-DGGML_METAL=ON
```
